### PR TITLE
feat: create alarms for throttling reads and writes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -70,6 +70,13 @@ jobs:
         id: minMax
         uses: clowdhaus/terraform-min-max@v1.2.7
 
+      - name: Install hcledit
+        run: |
+          wget https://github.com/minamijoyo/hcledit/releases/download/v0.2.15/hcledit_0.2.15_linux_amd64.tar.gz
+          tar xaf hcledit_0.2.15_linux_amd64.tar.gz hcledit
+          mv hcledit /usr/local/bin/
+          rm hcledit_0.2.15_linux_amd64.tar.gz
+
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
         uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+
+## [3.0.0](https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table/compare/v2.0.0...v3.0.0) (2024-11-08)
+
+
+### ⚠ BREAKING CHANGES
+
+* Bump TF version to 1.3.
+* Renamed `attributes` parameter to `table_attributes`. `attributes` is now used as an attribute for the table context.
+
+### Features
+
+* Allow creation of alarms for throttling reads and writes.
+
 ## [2.2.0](https://github.com/justtrackio/terraform-aws-dynamodb-table/compare/v2.1.0...v2.2.0) (2024-04-10)
 
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ module "dynamodb_table" {
   name     = "my-table"
   hash_key = "id"
 
-  attributes = [
+  table_attributes = [
     {
       name = "id"
       type = "N"
@@ -59,7 +59,7 @@ Users of Terragrunt can achieve similar results by using modules provided in the
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.44 |
 
 ## Providers
@@ -74,6 +74,7 @@ Users of Terragrunt can achieve similar results by using modules provided in the
 |------|--------|---------|
 | <a name="module_index_read_schedule"></a> [index\_read\_schedule](#module\_index\_read\_schedule) | ./module | n/a |
 | <a name="module_index_write_schedule"></a> [index\_write\_schedule](#module\_index\_write\_schedule) | ./module | n/a |
+| <a name="module_this"></a> [this](#module\_this) | justtrackio/label/null | 0.26.0 |
 
 ## Resources
 
@@ -89,6 +90,10 @@ Users of Terragrunt can achieve similar results by using modules provided in the
 | [aws_appautoscaling_target.index_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target) | resource |
 | [aws_appautoscaling_target.table_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target) | resource |
 | [aws_appautoscaling_target.table_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target) | resource |
+| [aws_cloudwatch_metric_alarm.read_gsi_throttles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.read_throttles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.write_gsi_throttles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.write_throttles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_dynamodb_resource_policy.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_resource_policy) | resource |
 | [aws_dynamodb_table.autoscaled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_dynamodb_table.autoscaled_gsi_ignore](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
@@ -100,23 +105,42 @@ Users of Terragrunt can achieve similar results by using modules provided in the
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_attributes"></a> [attributes](#input\_attributes) | List of nested attribute definitions. Only required for hash\_key and range\_key attributes. Each attribute has two properties: name - (Required) The name of the attribute, type - (Required) Attribute type, which must be a scalar type: S, N, or B for (S)tring, (N)umber or (B)inary data | `list(map(string))` | `[]` | no |
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_alarm"></a> [alarm](#input\_alarm) | The details of the alarm such as datapoints to alarm, evaluation periods, period, and threshold. | <pre>object({<br>    datapoints_to_alarm = optional(number, 3)<br>    evaluation_periods  = optional(number, 3)<br>    period              = optional(number, 60)<br>    threshold           = optional(number, 0)<br>  })</pre> | `{}` | no |
+| <a name="input_alarm_enabled"></a> [alarm\_enabled](#input\_alarm\_enabled) | Defines if throttling alarms should be created. | `bool` | `false` | no |
+| <a name="input_alarm_topic_arn"></a> [alarm\_topic\_arn](#input\_alarm\_topic\_arn) | The ARN of the SNS Topic used for notifying about alarm/ok messages. | `string` | `null` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_autoscaling_defaults"></a> [autoscaling\_defaults](#input\_autoscaling\_defaults) | A map of default autoscaling settings | `map(string)` | <pre>{<br>  "scale_in_cooldown": 0,<br>  "scale_out_cooldown": 0,<br>  "target_value": 70<br>}</pre> | no |
 | <a name="input_autoscaling_enabled"></a> [autoscaling\_enabled](#input\_autoscaling\_enabled) | Whether or not to enable autoscaling. See note in README about this setting | `bool` | `false` | no |
 | <a name="input_autoscaling_indexes"></a> [autoscaling\_indexes](#input\_autoscaling\_indexes) | A map of index autoscaling configurations. See example in examples/autoscaling | `map(map(string))` | `{}` | no |
 | <a name="input_autoscaling_read"></a> [autoscaling\_read](#input\_autoscaling\_read) | A map of read autoscaling settings. `max_capacity` is the only required key. See example in examples/autoscaling | `map(string)` | `{}` | no |
 | <a name="input_autoscaling_write"></a> [autoscaling\_write](#input\_autoscaling\_write) | A map of write autoscaling settings. `max_capacity` is the only required key. See example in examples/autoscaling | `map(string)` | `{}` | no |
+| <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | AWS account id | `string` | `null` | no |
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `null` | no |
 | <a name="input_billing_mode"></a> [billing\_mode](#input\_billing\_mode) | Controls how you are billed for read/write throughput and how you manage capacity. The valid values are PROVISIONED or PAY\_PER\_REQUEST | `string` | `"PAY_PER_REQUEST"` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
 | <a name="input_create_table"></a> [create\_table](#input\_create\_table) | Controls if DynamoDB table and associated resources are created | `bool` | `true` | no |
 | <a name="input_deletion_protection_enabled"></a> [deletion\_protection\_enabled](#input\_deletion\_protection\_enabled) | Enables deletion protection for table | `bool` | `null` | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_global_secondary_indexes"></a> [global\_secondary\_indexes](#input\_global\_secondary\_indexes) | Describe a GSI for the table; subject to the normal limits on the number of GSIs, projected attributes, etc. | `any` | `[]` | no |
 | <a name="input_hash_key"></a> [hash\_key](#input\_hash\_key) | The attribute to use as the hash (partition) key. Must also be defined as an attribute | `string` | `null` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_ignore_changes_global_secondary_index"></a> [ignore\_changes\_global\_secondary\_index](#input\_ignore\_changes\_global\_secondary\_index) | Whether to ignore changes lifecycle to global secondary indices, useful for provisioned tables with scaling | `bool` | `false` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br>set as tag values, and output by this module individually.<br>Does not affect values of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br>Default is to include all labels.<br>Tags with empty values will not be included in the `tags` output.<br>Set to `[]` to suppress all generated tags.<br>**Notes:**<br>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br>  "default"<br>]</pre> | no |
 | <a name="input_local_secondary_indexes"></a> [local\_secondary\_indexes](#input\_local\_secondary\_indexes) | Describe an LSI on the table; these can only be allocated at creation so you cannot change this definition after you have created the resource. | `any` | `[]` | no |
-| <a name="input_name"></a> [name](#input\_name) | Name of the DynamoDB table | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
+| <a name="input_organizational_unit"></a> [organizational\_unit](#input\_organizational\_unit) | Usually used to indicate the AWS organizational unit, e.g. 'prod', 'sdlc' | `string` | `null` | no |
 | <a name="input_point_in_time_recovery_enabled"></a> [point\_in\_time\_recovery\_enabled](#input\_point\_in\_time\_recovery\_enabled) | Whether to enable point-in-time recovery | `bool` | `false` | no |
 | <a name="input_range_key"></a> [range\_key](#input\_range\_key) | The attribute to use as the range (sort) key. Must also be defined as an attribute | `string` | `null` | no |
 | <a name="input_read_capacity"></a> [read\_capacity](#input\_read\_capacity) | The number of read units for this table. If the billing\_mode is PROVISIONED, this field should be greater than 0 | `number` | `null` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_replica_regions"></a> [replica\_regions](#input\_replica\_regions) | Region names for creating replicas for a global DynamoDB table. | `any` | `[]` | no |
 | <a name="input_schedule_scaling_indexes_read"></a> [schedule\_scaling\_indexes\_read](#input\_schedule\_scaling\_indexes\_read) | A map of index schedule scaling configurations. See example in examples/autoscaling | <pre>map(list(object({<br>    schedule     = string<br>    min_capacity = number<br>    max_capacity = number<br>  })))</pre> | `{}` | no |
 | <a name="input_schedule_scaling_indexes_write"></a> [schedule\_scaling\_indexes\_write](#input\_schedule\_scaling\_indexes\_write) | A map of index schedule scaling configurations. See example in examples/autoscaling | <pre>map(list(object({<br>    schedule     = string<br>    min_capacity = number<br>    max_capacity = number<br>  })))</pre> | `{}` | no |
@@ -124,8 +148,10 @@ Users of Terragrunt can achieve similar results by using modules provided in the
 | <a name="input_schedule_scaling_write"></a> [schedule\_scaling\_write](#input\_schedule\_scaling\_write) | A map of write schedule scaling settings. See example in examples/autoscaling | <pre>list(object({<br>    schedule     = string<br>    min_capacity = number<br>    max_capacity = number<br>  }))</pre> | `[]` | no |
 | <a name="input_server_side_encryption_enabled"></a> [server\_side\_encryption\_enabled](#input\_server\_side\_encryption\_enabled) | Whether or not to enable encryption at rest using an AWS managed KMS customer master key (CMK) | `bool` | `false` | no |
 | <a name="input_server_side_encryption_kms_key_arn"></a> [server\_side\_encryption\_kms\_key\_arn](#input\_server\_side\_encryption\_kms\_key\_arn) | The ARN of the CMK that should be used for the AWS KMS encryption. This attribute should only be specified if the key is different from the default DynamoDB CMK, alias/aws/dynamodb. | `string` | `null` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_stream_enabled"></a> [stream\_enabled](#input\_stream\_enabled) | Indicates whether Streams are to be enabled (true) or disabled (false). | `bool` | `false` | no |
 | <a name="input_stream_view_type"></a> [stream\_view\_type](#input\_stream\_view\_type) | When an item in the table is modified, StreamViewType determines what information is written to the table's stream. Valid values are KEYS\_ONLY, NEW\_IMAGE, OLD\_IMAGE, NEW\_AND\_OLD\_IMAGES. | `string` | `null` | no |
+| <a name="input_table_attributes"></a> [table\_attributes](#input\_table\_attributes) | List of nested attribute definitions. Only required for hash\_key and range\_key attributes. Each attribute has two properties: name - (Required) The name of the attribute, type - (Required) Attribute type, which must be a scalar type: S, N, or B for (S)tring, (N)umber or (B)inary data | `list(map(string))` | n/a | yes |
 | <a name="input_table_class"></a> [table\_class](#input\_table\_class) | The storage class of the table. Valid values are STANDARD and STANDARD\_INFREQUENT\_ACCESS | `string` | `null` | no |
 | <a name="input_table_policy_allow_actions"></a> [table\_policy\_allow\_actions](#input\_table\_policy\_allow\_actions) | Set which actions are allowed for the given principal | `list(string)` | <pre>[<br>  "dynamodb:*"<br>]</pre> | no |
 | <a name="input_table_policy_allow_principal_identifiers"></a> [table\_policy\_allow\_principal\_identifiers](#input\_table\_policy\_allow\_principal\_identifiers) | Set which principals to allow access to the table | `list(string)` | `[]` | no |
@@ -133,7 +159,8 @@ Users of Terragrunt can achieve similar results by using modules provided in the
 | <a name="input_table_policy_condition_test"></a> [table\_policy\_condition\_test](#input\_table\_policy\_condition\_test) | Set which condition to use when checking access | `string` | `"ArnLike"` | no |
 | <a name="input_table_policy_condition_values"></a> [table\_policy\_condition\_values](#input\_table\_policy\_condition\_values) | Set which conditional values to allow access to the table | `list(string)` | `[]` | no |
 | <a name="input_table_policy_condition_variable"></a> [table\_policy\_condition\_variable](#input\_table\_policy\_condition\_variable) | Set which conditional variable check to allow access to the table | `string` | `"aws:PrincipalArn"` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
+| <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
 | <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Updated Terraform resource management timeouts | `map(string)` | <pre>{<br>  "create": "10m",<br>  "delete": "10m",<br>  "update": "60m"<br>}</pre> | no |
 | <a name="input_ttl_attribute_name"></a> [ttl\_attribute\_name](#input\_ttl\_attribute\_name) | The name of the table attribute to store the TTL timestamp in | `string` | `"ttl"` | no |
 | <a name="input_ttl_enabled"></a> [ttl\_enabled](#input\_ttl\_enabled) | Indicates whether ttl is enabled | `bool` | `false` | no |

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -1,5 +1,5 @@
 resource "aws_appautoscaling_target" "table_read" {
-  count = var.create_table && var.autoscaling_enabled && length(var.autoscaling_read) > 0 ? 1 : 0
+  count = module.this.enabled && var.create_table && var.autoscaling_enabled && length(var.autoscaling_read) > 0 ? 1 : 0
 
   max_capacity       = var.autoscaling_read["max_capacity"]
   min_capacity       = var.read_capacity
@@ -9,7 +9,7 @@ resource "aws_appautoscaling_target" "table_read" {
 }
 
 resource "aws_appautoscaling_policy" "table_read_policy" {
-  count = var.create_table && var.autoscaling_enabled && length(var.autoscaling_read) > 0 ? 1 : 0
+  count = module.this.enabled && var.create_table && var.autoscaling_enabled && length(var.autoscaling_read) > 0 ? 1 : 0
 
   name               = "DynamoDBReadCapacityUtilization:${aws_appautoscaling_target.table_read[0].resource_id}"
   policy_type        = "TargetTrackingScaling"
@@ -29,7 +29,7 @@ resource "aws_appautoscaling_policy" "table_read_policy" {
 }
 
 resource "aws_appautoscaling_target" "table_write" {
-  count = var.create_table && var.autoscaling_enabled && length(var.autoscaling_write) > 0 ? 1 : 0
+  count = module.this.enabled && var.create_table && var.autoscaling_enabled && length(var.autoscaling_write) > 0 ? 1 : 0
 
   max_capacity       = var.autoscaling_write["max_capacity"]
   min_capacity       = var.write_capacity
@@ -39,7 +39,7 @@ resource "aws_appautoscaling_target" "table_write" {
 }
 
 resource "aws_appautoscaling_policy" "table_write_policy" {
-  count = var.create_table && var.autoscaling_enabled && length(var.autoscaling_write) > 0 ? 1 : 0
+  count = module.this.enabled && var.create_table && var.autoscaling_enabled && length(var.autoscaling_write) > 0 ? 1 : 0
 
   name               = "DynamoDBWriteCapacityUtilization:${aws_appautoscaling_target.table_write[0].resource_id}"
   policy_type        = "TargetTrackingScaling"
@@ -59,7 +59,7 @@ resource "aws_appautoscaling_policy" "table_write_policy" {
 }
 
 resource "aws_appautoscaling_target" "index_read" {
-  for_each = var.create_table && var.autoscaling_enabled ? var.autoscaling_indexes : {}
+  for_each = module.this.enabled && var.create_table && var.autoscaling_enabled ? var.autoscaling_indexes : {}
 
   max_capacity       = each.value["read_max_capacity"]
   min_capacity       = each.value["read_min_capacity"]
@@ -69,7 +69,7 @@ resource "aws_appautoscaling_target" "index_read" {
 }
 
 resource "aws_appautoscaling_policy" "index_read_policy" {
-  for_each = var.create_table && var.autoscaling_enabled ? var.autoscaling_indexes : {}
+  for_each = module.this.enabled && var.create_table && var.autoscaling_enabled ? var.autoscaling_indexes : {}
 
   name               = "DynamoDBReadCapacityUtilization:${aws_appautoscaling_target.index_read[each.key].resource_id}"
   policy_type        = "TargetTrackingScaling"
@@ -89,7 +89,7 @@ resource "aws_appautoscaling_policy" "index_read_policy" {
 }
 
 resource "aws_appautoscaling_target" "index_write" {
-  for_each = var.create_table && var.autoscaling_enabled ? var.autoscaling_indexes : {}
+  for_each = module.this.enabled && var.create_table && var.autoscaling_enabled ? var.autoscaling_indexes : {}
 
   max_capacity       = each.value["write_max_capacity"]
   min_capacity       = each.value["write_min_capacity"]
@@ -99,7 +99,7 @@ resource "aws_appautoscaling_target" "index_write" {
 }
 
 resource "aws_appautoscaling_policy" "index_write_policy" {
-  for_each = var.create_table && var.autoscaling_enabled ? var.autoscaling_indexes : {}
+  for_each = module.this.enabled && var.create_table && var.autoscaling_enabled ? var.autoscaling_indexes : {}
 
   name               = "DynamoDBWriteCapacityUtilization:${aws_appautoscaling_target.index_write[each.key].resource_id}"
   policy_type        = "TargetTrackingScaling"

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,0 +1,146 @@
+locals {
+  alarm_description = "DynamoDB table metrics: https://${module.this.aws_region}.console.aws.amazon.com/dynamodbv2/home?region=${module.this.aws_region}#table?name=${var.name}&tab=monitoring"
+  alarm_topic_arn   = var.alarm_topic_arn != null ? var.alarm_topic_arn : "arn:aws:sns:${module.this.aws_region}:${module.this.aws_account_id}:${module.this.environment}-alarms"
+}
+
+resource "aws_cloudwatch_metric_alarm" "read_throttles" {
+  count = module.this.enabled && var.alarm_enabled ? 1 : 0
+
+  alarm_description = jsonencode(merge({
+    Severity    = "warning"
+    Description = local.alarm_description
+  }, module.this.tags, module.this.additional_tag_map))
+  alarm_name          = "${var.name}-table-reads-throttling"
+  comparison_operator = "GreaterThanThreshold"
+  datapoints_to_alarm = var.alarm.datapoints_to_alarm
+  evaluation_periods  = var.alarm.evaluation_periods
+  threshold           = var.alarm.threshold
+  treat_missing_data  = "notBreaching"
+
+  metric_query {
+    id          = "throttles"
+    return_data = true
+
+    metric {
+      dimensions = {
+        TableName = var.name
+      }
+      metric_name = "ReadThrottleEvents"
+      namespace   = "AWS/DynamoDB"
+      period      = var.alarm.period
+      stat        = "Sum"
+    }
+  }
+
+  alarm_actions = [local.alarm_topic_arn]
+  ok_actions    = [local.alarm_topic_arn]
+
+  tags = module.this.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "write_throttles" {
+  count = module.this.enabled && var.alarm_enabled ? 1 : 0
+
+  alarm_description = jsonencode(merge({
+    Severity    = "warning"
+    Description = local.alarm_description
+  }, module.this.tags, module.this.additional_tag_map))
+  alarm_name          = "${var.name}-table-writes-throttling"
+  comparison_operator = "GreaterThanThreshold"
+  datapoints_to_alarm = var.alarm.datapoints_to_alarm
+  evaluation_periods  = var.alarm.evaluation_periods
+  threshold           = var.alarm.threshold
+  treat_missing_data  = "notBreaching"
+
+  metric_query {
+    id          = "throttles"
+    return_data = true
+
+    metric {
+      dimensions = {
+        TableName = var.name
+      }
+      metric_name = "WriteThrottleEvents"
+      namespace   = "AWS/DynamoDB"
+      period      = var.alarm.period
+      stat        = "Sum"
+    }
+  }
+
+  alarm_actions = [local.alarm_topic_arn]
+  ok_actions    = [local.alarm_topic_arn]
+
+  tags = module.this.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "read_gsi_throttles" {
+  for_each = module.this.enabled && var.alarm_enabled ? { for index, gsi in var.global_secondary_indexes : gsi.name => gsi } : {}
+
+  alarm_description = jsonencode(merge({
+    Severity    = "warning"
+    Description = local.alarm_description
+  }, module.this.tags, module.this.additional_tag_map))
+  alarm_name          = "${var.name}-gsi-${each.key}-reads-throttling"
+  comparison_operator = "GreaterThanThreshold"
+  datapoints_to_alarm = var.alarm.datapoints_to_alarm
+  evaluation_periods  = var.alarm.evaluation_periods
+  threshold           = var.alarm.threshold
+  treat_missing_data  = "notBreaching"
+
+  metric_query {
+    id          = "throttles"
+    return_data = true
+
+    metric {
+      dimensions = {
+        TableName                = var.name
+        GlobalSecondaryIndexName = each.key
+      }
+      metric_name = "ReadThrottleEvents"
+      namespace   = "AWS/DynamoDB"
+      period      = var.alarm.period
+      stat        = "Sum"
+    }
+  }
+
+  alarm_actions = [local.alarm_topic_arn]
+  ok_actions    = [local.alarm_topic_arn]
+
+  tags = module.this.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "write_gsi_throttles" {
+  for_each = module.this.enabled && var.alarm_enabled ? { for index, gsi in var.global_secondary_indexes : gsi.name => gsi } : {}
+
+  alarm_description = jsonencode(merge({
+    Severity    = "warning"
+    Description = local.alarm_description
+  }, module.this.tags, module.this.additional_tag_map))
+  alarm_name          = "${var.name}-gsi-${each.key}-writes-throttling"
+  comparison_operator = "GreaterThanThreshold"
+  datapoints_to_alarm = var.alarm.datapoints_to_alarm
+  evaluation_periods  = var.alarm.evaluation_periods
+  threshold           = var.alarm.threshold
+  treat_missing_data  = "notBreaching"
+
+  metric_query {
+    id          = "throttles"
+    return_data = true
+
+    metric {
+      dimensions = {
+        TableName                = var.name
+        GlobalSecondaryIndexName = each.key
+      }
+      metric_name = "WriteThrottleEvents"
+      namespace   = "AWS/DynamoDB"
+      period      = var.alarm.period
+      stat        = "Sum"
+    }
+  }
+
+  alarm_actions = [local.alarm_topic_arn]
+  ok_actions    = [local.alarm_topic_arn]
+
+  tags = module.this.tags
+}

--- a/context.tf
+++ b/context.tf
@@ -1,0 +1,300 @@
+#
+# ONLY EDIT THIS FILE IN github.com/justtrackio/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/justtrackio/terraform-null-label/blob/main/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# justtrack's standard configuration inputs suitable for passing
+# to justtrack modules.
+#
+# curl -sL https://raw.githubusercontent.com/justtrackio/terraform-null-label/main/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "justtrackio/label/null"
+  version = "0.26.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+  aws_account_id      = var.aws_account_id
+  aws_region          = var.aws_region
+  organizational_unit = var.organizational_unit
+
+  context = var.context
+}
+
+# Copy contents of justtrackio/terraform-null-label/variables.tf here
+
+variable "context" { # tflint-ignore: terraform_standard_module_structure
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" { # tflint-ignore: terraform_standard_module_structure
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" { # tflint-ignore: terraform_standard_module_structure
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" { # tflint-ignore: terraform_standard_module_structure
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" { # tflint-ignore: terraform_standard_module_structure
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" { # tflint-ignore: terraform_standard_module_structure
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" { # tflint-ignore: terraform_standard_module_structure
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" { # tflint-ignore: terraform_standard_module_structure
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" { # tflint-ignore: terraform_standard_module_structure
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" { # tflint-ignore: terraform_standard_module_structure
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" { # tflint-ignore: terraform_standard_module_structure
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" { # tflint-ignore: terraform_standard_module_structure
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" { # tflint-ignore: terraform_standard_module_structure
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" { # tflint-ignore: terraform_standard_module_structure
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" { # tflint-ignore: terraform_standard_module_structure
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" { # tflint-ignore: terraform_standard_module_structure
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" { # tflint-ignore: terraform_standard_module_structure
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" { # tflint-ignore: terraform_standard_module_structure
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+variable "aws_account_id" { # tflint-ignore: terraform_standard_module_structure
+  type        = string
+  description = "AWS account id"
+  default     = null
+}
+
+variable "aws_region" { # tflint-ignore: terraform_standard_module_structure
+  type        = string
+  description = "AWS region"
+  default     = null
+}
+
+variable "organizational_unit" { # tflint-ignore: terraform_standard_module_structure
+  type        = string
+  description = "Usually used to indicate the AWS organizational unit, e.g. 'prod', 'sdlc'"
+  default     = null
+}
+
+#### End of copy of justtrackio/terraform-null-label/variables.tf

--- a/examples/autoscaling/README.md
+++ b/examples/autoscaling/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.69 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 

--- a/examples/autoscaling/main.tf
+++ b/examples/autoscaling/main.tf
@@ -97,7 +97,7 @@ module "dynamodb_table" {
     ]
   }
 
-  attributes = [
+  table_attributes = [
     {
       name = "id"
       type = "N"
@@ -132,6 +132,8 @@ module "dynamodb_table" {
 
 module "disabled_dynamodb_table" {
   source = "../../"
+
+  table_attributes = []
 
   create_table = false
 }

--- a/examples/autoscaling/versions.tf
+++ b/examples/autoscaling/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.69 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -15,7 +15,7 @@ module "dynamodb_table" {
   table_class                 = "STANDARD"
   deletion_protection_enabled = false
 
-  attributes = [
+  table_attributes = [
     {
       name = "id"
       type = "N"
@@ -49,6 +49,8 @@ module "dynamodb_table" {
 
 module "disabled_dynamodb_table" {
   source = "../../"
+
+  table_attributes = []
 
   create_table = false
 }

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {

--- a/examples/global-tables/README.md
+++ b/examples/global-tables/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.23 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 

--- a/examples/global-tables/main.tf
+++ b/examples/global-tables/main.tf
@@ -50,7 +50,7 @@ module "dynamodb_table" {
   server_side_encryption_enabled     = true
   server_side_encryption_kms_key_arn = aws_kms_key.primary.arn
 
-  attributes = [
+  table_attributes = [
     {
       name = "id"
       type = "N"

--- a/examples/global-tables/versions.tf
+++ b/examples/global-tables/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {

--- a/module/versions.tf
+++ b/module/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {

--- a/schedulescaling.tf
+++ b/schedulescaling.tf
@@ -1,5 +1,5 @@
 resource "aws_appautoscaling_scheduled_action" "table_read_schedule" {
-  for_each = var.create_table && var.autoscaling_enabled && length(var.schedule_scaling_read) > 0 ? { for k, v in var.schedule_scaling_read : k => v } : {}
+  for_each = module.this.enabled && var.create_table && var.autoscaling_enabled && length(var.schedule_scaling_read) > 0 ? { for k, v in var.schedule_scaling_read : k => v } : {}
 
   name = "DynamoDBReadCapacityUtilization-${replace(aws_appautoscaling_target.table_read[0].resource_id, "/", "-")}-${each.key}"
 
@@ -16,7 +16,7 @@ resource "aws_appautoscaling_scheduled_action" "table_read_schedule" {
 }
 
 module "index_read_schedule" {
-  for_each = var.create_table && length(var.schedule_scaling_indexes_read) > 0 ? var.autoscaling_indexes : {}
+  for_each = module.this.enabled && var.create_table && length(var.schedule_scaling_indexes_read) > 0 ? var.autoscaling_indexes : {}
   source   = "./module"
 
   name = "DynamoDBReadCapacityUtilization-${replace(aws_appautoscaling_target.index_read[each.key].resource_id, "/", "-")}"
@@ -29,7 +29,7 @@ module "index_read_schedule" {
 }
 
 resource "aws_appautoscaling_scheduled_action" "table_write_schedule" {
-  for_each = var.create_table && var.autoscaling_enabled && length(var.schedule_scaling_write) > 0 ? { for k, v in var.schedule_scaling_write : k => v } : {}
+  for_each = module.this.enabled && var.create_table && var.autoscaling_enabled && length(var.schedule_scaling_write) > 0 ? { for k, v in var.schedule_scaling_write : k => v } : {}
 
   name = "DynamoDBWriteCapacityUtilization-${replace(aws_appautoscaling_target.table_write[0].resource_id, "/", "-")}-${each.key}"
 
@@ -46,7 +46,7 @@ resource "aws_appautoscaling_scheduled_action" "table_write_schedule" {
 }
 
 module "index_write_schedule" {
-  for_each = var.create_table && length(var.schedule_scaling_indexes_write) > 0 ? var.autoscaling_indexes : {}
+  for_each = module.this.enabled && var.create_table && length(var.schedule_scaling_indexes_write) > 0 ? var.autoscaling_indexes : {}
   source   = "./module"
 
   name = "DynamoDBWriteCapacityUtilization-${replace(aws_appautoscaling_target.index_write[each.key].resource_id, "/", "-")}"

--- a/variables.tf
+++ b/variables.tf
@@ -4,16 +4,9 @@ variable "create_table" {
   default     = true
 }
 
-variable "name" {
-  description = "Name of the DynamoDB table"
-  type        = string
-  default     = null
-}
-
-variable "attributes" {
+variable "table_attributes" {
   description = "List of nested attribute definitions. Only required for hash_key and range_key attributes. Each attribute has two properties: name - (Required) The name of the attribute, type - (Required) Attribute type, which must be a scalar type: S, N, or B for (S)tring, (N)umber or (B)inary data"
   type        = list(map(string))
-  default     = []
 }
 
 variable "hash_key" {
@@ -106,12 +99,6 @@ variable "server_side_encryption_kms_key_arn" {
   default     = null
 }
 
-variable "tags" {
-  description = "A map of tags to add to all resources"
-  type        = map(string)
-  default     = {}
-}
-
 variable "timeouts" {
   description = "Updated Terraform resource management timeouts"
   type        = map(string)
@@ -120,6 +107,29 @@ variable "timeouts" {
     update = "60m"
     delete = "10m"
   }
+}
+
+variable "alarm" {
+  type = object({
+    datapoints_to_alarm = optional(number, 3)
+    evaluation_periods  = optional(number, 3)
+    period              = optional(number, 60)
+    threshold           = optional(number, 0)
+  })
+  description = "The details of the alarm such as datapoints to alarm, evaluation periods, period, and threshold."
+  default     = {}
+}
+
+variable "alarm_enabled" {
+  type        = bool
+  description = "Defines if throttling alarms should be created."
+  default     = false
+}
+
+variable "alarm_topic_arn" {
+  type        = string
+  description = "The ARN of the SNS Topic used for notifying about alarm/ok messages."
+  default     = null
 }
 
 variable "autoscaling_enabled" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -3,9 +3,54 @@ module "wrapper" {
 
   for_each = var.items
 
-  create_table                       = try(each.value.create_table, var.defaults.create_table, true)
+  context = try(each.value.context, var.defaults.context, {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+
+
+
+
+
+
+
+    labels_as_tags = ["unset"]
+  })
+  enabled                            = try(each.value.enabled, var.defaults.enabled, null)
+  namespace                          = try(each.value.namespace, var.defaults.namespace, null)
+  tenant                             = try(each.value.tenant, var.defaults.tenant, null)
+  environment                        = try(each.value.environment, var.defaults.environment, null)
+  stage                              = try(each.value.stage, var.defaults.stage, null)
   name                               = try(each.value.name, var.defaults.name, null)
+  delimiter                          = try(each.value.delimiter, var.defaults.delimiter, null)
   attributes                         = try(each.value.attributes, var.defaults.attributes, [])
+  labels_as_tags                     = try(each.value.labels_as_tags, var.defaults.labels_as_tags, ["default"])
+  tags                               = try(each.value.tags, var.defaults.tags, {})
+  additional_tag_map                 = try(each.value.additional_tag_map, var.defaults.additional_tag_map, {})
+  label_order                        = try(each.value.label_order, var.defaults.label_order, null)
+  regex_replace_chars                = try(each.value.regex_replace_chars, var.defaults.regex_replace_chars, null)
+  id_length_limit                    = try(each.value.id_length_limit, var.defaults.id_length_limit, null)
+  label_key_case                     = try(each.value.label_key_case, var.defaults.label_key_case, null)
+  label_value_case                   = try(each.value.label_value_case, var.defaults.label_value_case, null)
+  descriptor_formats                 = try(each.value.descriptor_formats, var.defaults.descriptor_formats, {})
+  aws_account_id                     = try(each.value.aws_account_id, var.defaults.aws_account_id, null)
+  aws_region                         = try(each.value.aws_region, var.defaults.aws_region, null)
+  organizational_unit                = try(each.value.organizational_unit, var.defaults.organizational_unit, null)
+  create_table                       = try(each.value.create_table, var.defaults.create_table, true)
+  table_attributes                   = try(each.value.table_attributes, var.defaults.table_attributes)
   hash_key                           = try(each.value.hash_key, var.defaults.hash_key, null)
   range_key                          = try(each.value.range_key, var.defaults.range_key, null)
   billing_mode                       = try(each.value.billing_mode, var.defaults.billing_mode, "PAY_PER_REQUEST")
@@ -21,12 +66,14 @@ module "wrapper" {
   stream_view_type                   = try(each.value.stream_view_type, var.defaults.stream_view_type, null)
   server_side_encryption_enabled     = try(each.value.server_side_encryption_enabled, var.defaults.server_side_encryption_enabled, false)
   server_side_encryption_kms_key_arn = try(each.value.server_side_encryption_kms_key_arn, var.defaults.server_side_encryption_kms_key_arn, null)
-  tags                               = try(each.value.tags, var.defaults.tags, {})
   timeouts = try(each.value.timeouts, var.defaults.timeouts, {
     create = "10m"
     update = "60m"
     delete = "10m"
   })
+  alarm               = try(each.value.alarm, var.defaults.alarm, {})
+  alarm_enabled       = try(each.value.alarm_enabled, var.defaults.alarm_enabled, false)
+  alarm_topic_arn     = try(each.value.alarm_topic_arn, var.defaults.alarm_topic_arn, null)
   autoscaling_enabled = try(each.value.autoscaling_enabled, var.defaults.autoscaling_enabled, false)
   autoscaling_defaults = try(each.value.autoscaling_defaults, var.defaults.autoscaling_defaults, {
     scale_in_cooldown  = 0


### PR DESCRIPTION
This commit adds alarms for throttling reads and writes of the table or any of the GSIs. I needed to add the context.tf file, which conflicted with the name and attributes variables, so I had to rename the attributes of the table to table_attributes (the name was basically the same and I could just drop the duplicate).